### PR TITLE
Use latest Expo supported version of react-native-webview;

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
   },
   "homepage": "https://github.com/TradingPal/react-native-highcharts#readme",
   "dependencies": {
-    "react-native-webview": "^5.6.2"
+    "react-native-webview": "^7.0.5"
   }
 }


### PR DESCRIPTION
Expo apps using SDK v35 and up need to have this version of `react-native-webview` specified for it to work correctly. (source: https://blog.expo.io/expo-sdk-35-is-now-available-beee0dfafbf4)